### PR TITLE
Clarify key type in New Relic

### DIFF
--- a/plugins/new-relic/retention.yaml
+++ b/plugins/new-relic/retention.yaml
@@ -1,6 +1,6 @@
 documentationURL: "https://docs.newrelic.com/"
 configurations:
-  api-key: "New Relic license key (see https://one.newrelic.com/api-keys)"
+  api-key: "New Relic license key, must be an 'INGEST - LICENSE' key (see https://one.newrelic.com/api-keys)"
 defaultExportURL: "otlp.nr-data.net:443"
 allowCustomExportURL: true
 presetScripts:


### PR DESCRIPTION
users ran into an issue choosing the wrong key type for New Relic. Adding clarification here to reduce those mistakes and make it easier to address issues.