### PR TITLE
Add defaultDisabled field to preset scripts options

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The presetScripts object should adhere to the following format:
 | description       | string   | false        | A description about what the script exports, and the extra functionality it powers.                                                   |
 | script            | string   | true         | The PxL script.                                                                                                                       |
 | defaultFrequencyS | int      | false        | The default interval, in seconds, at which the script should be rerun. The user has the ability to change this interval if they wish. |
+| defaultDisabled   | boolean  | false        | Whether the preset script should be disabled by default.                                                                              |
 
 ## Testing a Plugin
 


### PR DESCRIPTION
Currently, when a user enables a plugin, all preset scripts get enabled.
We want to allow plugin providers to specify preset scripts that may not be enabled by default. This PR adds the `defaultDisabled` field to the README, which plugin providers can now use to specify whether scripts should be disabled by default.