### PR TITLE
Fix formatting for kafka_spans

### DIFF
--- a/plugins/new-relic/retention.yaml
+++ b/plugins/new-relic/retention.yaml
@@ -638,21 +638,21 @@ presetScripts:
           return df[[
               'calling_pod',
               'calling_service',
-          'client_id',
-          'destination',
+              'client_id',
+              'destination',
               'kafka_pod',
               'kafka_service',
-          'error_code',
-          'latency',
-          'message_size',
+              'error_code',
+              'latency',
+              'message_size',
               'namespace',
               'partition_idx',
               'partition',
               'req_body',
-          'req_cmd',
+              'req_cmd',
               'resp',
               'time_',
-          'topic_name',
+              'topic_name',
           ]]
 
 


### PR DESCRIPTION
When copying the script over, formatting got messed up. It wasn't a functional error, but aesthetically was bothering me. Here's the fix.
Signed-off-by: Phillip Kuznetsov <pkuznetsov@pixielabs.ai>