### PR TITLE
Add units to OTel metrics.

### DIFF
--- a/plugins/new-relic/retention.yaml
+++ b/plugins/new-relic/retention.yaml
@@ -53,8 +53,7 @@ presetScripts:
             px.otel.metric.Summary(
               name='http.server.duration',
               description='measures the duration of the inbound HTTP request',
-              # Unit is not supported yet
-              # unit='ms',
+              unit='ms',
               count=df.latency_count,
               sum=df.latency_sum,
               quantile_values={
@@ -217,40 +216,35 @@ presetScripts:
             px.otel.metric.Gauge(
               name='runtime.jvm.gc.collection',
               description='',
-              # Unit is not supported yet
-              # unit='ms',
+              unit='ms',
               value=df.young_gc_time,
               attributes={'gc': df.young},
             ),
             px.otel.metric.Gauge(
               name='runtime.jvm.gc.collection',
               description=''
-              # Unit is not supported yet
-              # unit='ms',
+              unit='ms',
               value=df.full_gc_time,
               attributes={'gc': df.full},
             ),
             px.otel.metric.Gauge(
               name='runtime.memory.area',
               description=''
-              # Unit is not supported yet
-              # unit='bytes',
+              unit='bytes',
               value=df.used_heap_size,
               attributes={'type': df.used, 'area': df.heap},
             ),
             px.otel.metric.Gauge(
               name='runtime.memory.area',
               description=''
-              # Unit is not supported yet
-              # unit='bytes',
+              unit='bytes',
               value=df.total_heap_size,
               attributes={'type': df.total, 'area': df.heap},
             ),
             px.otel.metric.Gauge(
               name='runtime.memory.area',
               description=''
-              # Unit is not supported yet
-              # unit='bytes',
+              unit='bytes',
               value=df.max_heap_size,
               attributes={'type': df.max, 'area': df.heap},
             ),


### PR DESCRIPTION
Looks like units are now supported for `px.otel.metric.Gauge` and `px.otel.metric.Summary` so we should uncomment these lines. https://docs.px.dev/reference/pxl/otel-export/