### PR TITLE
Ensure Postgres and MySQL send client and server side spans for a transaction

### DIFF
--- a/plugins/new-relic/retention.yaml
+++ b/plugins/new-relic/retention.yaml
@@ -1179,7 +1179,7 @@ presetScripts:
                       name=df.span_name,
                       start_time=df.start_time,
                       end_time=df.time_,
-                      kind=px.otel.trace.SPAN_KIND_CLIENT,
+                      kind=px.otel.trace.SPAN_KIND_SERVER,
                       attributes={
                           "kafka.client_id": df.client_id,
                           "kafka.has_error": df.has_error,
@@ -1278,7 +1278,7 @@ presetScripts:
             name=df.req_cmd,
             start_time=df.start_time,
             end_time=df.time_,
-            kind=px.otel.trace.SPAN_KIND_CLIENT,
+            kind=px.otel.trace.SPAN_KIND_SERVER,
             attributes={
               'redis.req_bytes': df.req_bytes,
               'redis.resp_bytes': df.resp_bytes,
@@ -1639,7 +1639,7 @@ presetScripts:
             name='dns',
             start_time=df.start_time,
             end_time=df.time_,
-            kind=px.otel.trace.SPAN_KIND_CLIENT,
+            kind=px.otel.trace.SPAN_KIND_SERVER,
             attributes={
                 'dns.latency': df.latency,
                 'dns.req_body': df.req_body,
@@ -1761,7 +1761,7 @@ presetScripts:
               name=df.req_cmd,
               start_time=df.start_time,
               end_time=df.time_,
-              kind=px.otel.trace.SPAN_KIND_CLIENT,
+              kind=px.otel.trace.SPAN_KIND_SERVER,
             ),
           ],
         ),

--- a/plugins/new-relic/retention.yaml
+++ b/plugins/new-relic/retention.yaml
@@ -256,7 +256,6 @@ presetScripts:
     description: "This script generates span events from queries to PostgreSQL databases and sends them to New Relic's OTel endpoint."
     script: |
       #px:set max_output_rows_per_table=500
-
       import px
 
       def remove_ns_prefix(column):
@@ -265,31 +264,27 @@ presetScripts:
       def add_source_dest_columns(df):
         df.pod = df.ctx['pod']
         df.namespace = df.ctx['namespace']
+        df.container = df.ctx['container']
 
         # If remote_addr is a pod, get its name. If not, use IP address.
         df.ra_pod = px.pod_id_to_pod_name(px.ip_to_pod_id(df.remote_addr))
         df.is_ra_pod = df.ra_pod != ''
         df.ra_name = px.select(df.is_ra_pod, df.ra_pod, df.remote_addr)
-
         df.is_server_tracing = df.trace_role == 2
         df.is_source_pod_type = px.select(df.is_server_tracing, df.is_ra_pod, True)
         df.is_dest_pod_type = px.select(df.is_server_tracing, True, df.is_ra_pod)
-
         # Set client and server based on trace_role.
         df.source_pod = px.select(df.is_server_tracing, df.ra_name, df.pod)
         df.destination_pod = px.select(df.is_server_tracing, df.pod, df.ra_name)
-
-        df = df.drop(['ra_pod', 'is_ra_pod', 'ra_name', 'is_server_tracing'])
         df.source_service = px.pod_name_to_service_name(df.source_pod)
         df.destination_service = px.pod_name_to_service_name(df.destination_pod)
         df.destination_namespace = px.pod_name_to_namespace(df.destination_pod)
         df.source_namespace = px.pod_name_to_namespace(df.source_pod)
-
         df.source_service = remove_ns_prefix(df.source_service)
         df.destination_service = remove_ns_prefix(df.destination_service)
+        df.source_container = px.select(df.is_server_tracing, '', df.container)
         df.source_pod = remove_ns_prefix(df.source_pod)
         df.destination_pod = remove_ns_prefix(df.destination_pod)
-
         # If the destination service is missing then try the nslookup
         df.destination_service = px.select(
             df.destination_service != '',
@@ -302,22 +297,47 @@ presetScripts:
             df.destination_service,
             df.remote_addr,
         )
-        return df
+        return df.drop(['ra_pod', 'is_ra_pod', 'ra_name', 'is_server_tracing'])
 
       df = px.DataFrame('pgsql_events', start_time=px.plugin.start_time, end_time=px.plugin.end_time)
       df = add_source_dest_columns(df)
-
       df.normed_query_struct = px.normalize_pgsql(df.req, df.req_cmd)
       df.query = px.pluck(df.normed_query_struct, 'query')
       df = df[df.query != ""]
-
       df.start_time = df.time_ - df.latency
-
       df.cluster_name = px.vizier_name()
       df.cluster_id = px.vizier_id()
       df.pixie = 'pixie'
       df.db_system = 'postgres'
 
+      # Export client span format for the client side of the request
+      px.export(
+        df, px.otel.Data(
+          resource={
+            'service.name': df.source_service,
+            'k8s.container.name': df.source_container,
+            'service.instance.id': df.source_pod,
+            'k8s.pod.name': df.source_pod,
+            'k8s.namespace.name': df.source_namespace,
+            'px.cluster.id': df.cluster_id,
+            'k8s.cluster.name': df.cluster_name,
+            'instrumentation.provider': df.pixie,
+          },
+          data=[
+            px.otel.trace.Span(
+              name=df.query,
+              start_time=df.start_time,
+              end_time=df.time_,
+              kind=px.otel.trace.SPAN_KIND_CLIENT,
+              attributes={
+                'db.system': df.db_system,
+              },
+            ),
+          ],
+        ),
+      )
+
+      # Export server span format for the server (Postgres) side of the request
       px.export(
         df, px.otel.Data(
           resource={
@@ -336,7 +356,7 @@ presetScripts:
               name=df.query,
               start_time=df.start_time,
               end_time=df.time_,
-              kind=px.otel.trace.SPAN_KIND_CLIENT,
+              kind=px.otel.trace.SPAN_KIND_SERVER,
               attributes={
                 'db.system': df.db_system,
                 'postgres.req_cmd': df.req_cmd,
@@ -473,17 +493,14 @@ presetScripts:
 
       def remove_duplicate_traces(df):
           ''' Removes duplicate traces.
-
               For historical reasons, Pixie traces MySQL requests on both the client AND server side:
               https://github.com/pixie-io/pixie/blob/5e5598ac46f39219148a36468b5318b1466a92d4/src/stirling/source_connectors/socket_tracer/conn_tracker.cc#L639
           '''
-
           # Keep client-side traces if server is outside the cluster (can't be resolved to pod or svc)
           df.remote_pod_id = px.ip_to_pod_id(df.remote_addr)
           df.remote_service_id = px.ip_to_service_id(df.remote_addr)
           df.remote_outside_cluster = df.remote_pod_id == '' and df.remote_service_id == ''
           df_client_traces = df[df.trace_role == 1 and df.remote_outside_cluster]
-
           df_server_traces = df[df.trace_role == 2]
           df_server_traces.append(df_client_traces)
           return df_server_traces
@@ -494,31 +511,26 @@ presetScripts:
       def add_source_dest_columns(df):
           df.pod = df.ctx['pod']
           df.namespace = df.ctx['namespace']
-
+          df.container = df.ctx['container']
           # If remote_addr is a pod, get its name. If not, use IP address.
           df.ra_pod = px.pod_id_to_pod_name(px.ip_to_pod_id(df.remote_addr))
           df.is_ra_pod = df.ra_pod != ''
           df.ra_name = px.select(df.is_ra_pod, df.ra_pod, df.remote_addr)
-
           df.is_server_tracing = df.trace_role == 2
           df.is_source_pod_type = px.select(df.is_server_tracing, df.is_ra_pod, True)
           df.is_dest_pod_type = px.select(df.is_server_tracing, True, df.is_ra_pod)
-
           # Set client and server based on trace_role.
           df.source_pod = px.select(df.is_server_tracing, df.ra_name, df.pod)
           df.destination_pod = px.select(df.is_server_tracing, df.pod, df.ra_name)
-
-          df = df.drop(['ra_pod', 'is_ra_pod', 'ra_name', 'is_server_tracing'])
           df.source_service = px.pod_name_to_service_name(df.source_pod)
           df.destination_service = px.pod_name_to_service_name(df.destination_pod)
           df.destination_namespace = px.pod_name_to_namespace(df.destination_pod)
           df.source_namespace = px.pod_name_to_namespace(df.source_pod)
-
           df.source_service = remove_ns_prefix(df.source_service)
           df.destination_service = remove_ns_prefix(df.destination_service)
+          df.source_container = px.select(df.is_server_tracing, '', df.container)
           df.source_pod = remove_ns_prefix(df.source_pod)
           df.destination_pod = remove_ns_prefix(df.destination_pod)
-
           # If the destination service is missing then try the nslookup
           df.destination_service = px.select(
               df.destination_service != '',
@@ -531,16 +543,14 @@ presetScripts:
               df.destination_service,
               df.remote_addr,
           )
-          return df
+          return df.drop(['ra_pod', 'is_ra_pod', 'ra_name', 'is_server_tracing'])
 
       df = px.DataFrame('mysql_events', start_time=px.plugin.start_time, end_time=px.plugin.end_time)
       df = remove_duplicate_traces(df)
       df = add_source_dest_columns(df)
-
       df.normed_query_struct = px.normalize_mysql(df.req_body, df.req_cmd)
       df.query = px.pluck(df.normed_query_struct, 'query')
       df = df[df.query != ""]
-
       df.start_time = df.time_ - df.latency
       df.latency = df.latency / (1000 * 1000)
       df.req_bytes = px.length(df.req_body)
@@ -551,6 +561,34 @@ presetScripts:
       df.pixie = 'pixie'
       df.db_system = 'mysql'
 
+      # Export client span format for the client side of the request
+      px.export(
+        df, px.otel.Data(
+          resource={
+            'service.name': df.source_service,
+            'k8s.container.name': df.source_container,
+            'service.instance.id': df.source_pod,
+            'k8s.pod.name': df.source_pod,
+            'k8s.namespace.name': df.source_namespace,
+            'px.cluster.id': df.cluster_id,
+            'k8s.cluster.name': df.cluster_name,
+            'instrumentation.provider': df.pixie,
+          },
+          data=[
+            px.otel.trace.Span(
+              name=df.query,
+              start_time=df.start_time,
+              end_time=df.time_,
+              kind=px.otel.trace.SPAN_KIND_CLIENT,
+              attributes={
+                'db.system': df.db_system,
+              },
+            ),
+          ],
+        ),
+      )
+
+      # Export server span format for the server (MySQL) side of the reques
       px.export(
         df, px.otel.Data(
           resource={
@@ -569,7 +607,7 @@ presetScripts:
               name=df.query,
               start_time=df.start_time,
               end_time=df.time_,
-              kind=px.otel.trace.SPAN_KIND_CLIENT,
+              kind=px.otel.trace.SPAN_KIND_SERVER,
               attributes={
                 'mysql.req_cmd': df.req_cmd,
                 'mysql.req_body': df.req_body,


### PR DESCRIPTION
In OpenTelemetry format, we expect that there will be a client side span and a server side span for a given request. 

This diff ensures that both of those sides will be present for MySQL and postgres.

The Services - OpenTelemetry experience will look for client side spans (where the application calls out to the DB), and the Pixie entities experience will look for server side spans (where the DB receives a request from the application). 

This will allow us to match the Otel convention and support both experiences.

Signed-off-by: Natalie Serrino <nserrino@pixielabs.ai>