### PR TITLE
Fix errors that occur with the New Relic plugin

### DIFF
--- a/plugins/new-relic/plugin.yaml
+++ b/plugins/new-relic/plugin.yaml
@@ -3,7 +3,7 @@ id: "new-relic"
 logo: >
   <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M17.7865 8.30799V15.692L11.3928 19.3848V24L21.7857 18.0004V5.99963L17.7865 8.30799Z" fill="#00AC69"/><path d="M11.3929 4.61672L17.7866 8.30798L21.7858 5.99962L11.3929 0L1 5.99962L4.99774 8.30798L11.3929 4.61672Z" fill="#1CE783"/><path d="M7.39517 14.3091V21.6932L11.3929 24V12.0008L1 5.99963V10.6164L7.39517 14.3091Z" fill="white"/></svg>
 description: "The official New Relic plugin for Pixie. This plugin will help export your Pixie data to New Relic. Check out the tutorial: https://docs.pixielabs.ai/tutorials/integrations/nr-retention"
-version: "1.4.3"
+version: "1.4.4"
 updated: "2022-06-10"
 keywords:
   - newrelic

--- a/plugins/new-relic/retention.yaml
+++ b/plugins/new-relic/retention.yaml
@@ -310,58 +310,48 @@ presetScripts:
       df.pixie = 'pixie'
       df.db_system = 'postgres'
 
-      # Export client span format for the client side of the request
       px.export(
         df, px.otel.Data(
           resource={
             'service.name': df.source_service,
-            'k8s.container.name': df.source_container,
-            'service.instance.id': df.source_pod,
-            'k8s.pod.name': df.source_pod,
-            'k8s.namespace.name': df.source_namespace,
-            'px.cluster.id': df.cluster_id,
-            'k8s.cluster.name': df.cluster_name,
-            'instrumentation.provider': df.pixie,
           },
           data=[
+            # Export client span format for the client side of the request
             px.otel.trace.Span(
               name=df.query,
               start_time=df.start_time,
               end_time=df.time_,
               kind=px.otel.trace.SPAN_KIND_CLIENT,
               attributes={
+                'k8s.container.name': df.source_container,
+                'service.instance.id': df.source_pod,
+                'k8s.pod.name': df.source_pod,
+                'k8s.namespace.name': df.source_namespace,
+                'px.cluster.id': df.cluster_id,
+                'k8s.cluster.name': df.cluster_name,
+                'instrumentation.provider': df.pixie,
                 'db.system': df.db_system,
               },
             ),
-          ],
-        ),
-      )
-
-      # Export server span format for the server (Postgres) side of the request
-      px.export(
-        df, px.otel.Data(
-          resource={
-            'service.name': df.source_service,
-            'service.instance.id': df.source_pod,
-            'k8s.namespace.name': df.source_namespace,
-            'postgres.service.name': df.destination_service,
-            'postgres.pod.name': df.destination_pod,
-            'postgres.namespace.name': df.destination_namespace,
-            'k8s.cluster.name': df.cluster_name,
-            'px.cluster.id': df.cluster_id,
-            'instrumentation.provider': df.pixie,
-          },
-          data=[
+            # Export server span format for the server (Postgres) side of the request
             px.otel.trace.Span(
               name=df.query,
               start_time=df.start_time,
               end_time=df.time_,
               kind=px.otel.trace.SPAN_KIND_SERVER,
               attributes={
+                'service.instance.id': df.source_pod,
+                'k8s.namespace.name': df.source_namespace,
+                'postgres.service.name': df.destination_service,
+                'postgres.pod.name': df.destination_pod,
+                'postgres.namespace.name': df.destination_namespace,
+                'k8s.cluster.name': df.cluster_name,
+                'px.cluster.id': df.cluster_id,
+                'instrumentation.provider': df.pixie,
                 'db.system': df.db_system,
                 'postgres.req_cmd': df.req_cmd,
-                'postgres.req': df.req,
-                # Disabling sending df.resp for now until illegal characters are handled.
+                # Disabling sending df.req and df.resp for now until illegal characters are handled.
+                # 'postgres.req': df.req,
                 # 'postgres.resp': df.resp,
                 'postgres.resp_latency': df.latency,
               },

--- a/plugins/new-relic/retention.yaml
+++ b/plugins/new-relic/retention.yaml
@@ -561,54 +561,27 @@ presetScripts:
       df.pixie = 'pixie'
       df.db_system = 'mysql'
 
-      # Export client span format for the client side of the request
       px.export(
         df, px.otel.Data(
           resource={
             'service.name': df.source_service,
-            'k8s.container.name': df.source_container,
-            'service.instance.id': df.source_pod,
-            'k8s.pod.name': df.source_pod,
-            'k8s.namespace.name': df.source_namespace,
-            'px.cluster.id': df.cluster_id,
-            'k8s.cluster.name': df.cluster_name,
-            'instrumentation.provider': df.pixie,
           },
           data=[
-            px.otel.trace.Span(
-              name=df.query,
-              start_time=df.start_time,
-              end_time=df.time_,
-              kind=px.otel.trace.SPAN_KIND_CLIENT,
-              attributes={
-                'db.system': df.db_system,
-              },
-            ),
-          ],
-        ),
-      )
-
-      # Export server span format for the server (MySQL) side of the reques
-      px.export(
-        df, px.otel.Data(
-          resource={
-            'service.name': df.source_service,
-            'service.instance.id': df.source_pod,
-            'k8s.namespace.name': df.source_namespace,
-            'mysql.service.name': df.destination_service,
-            'mysql.pod.name': df.destination_pod,
-            'mysql.namespace.name': df.destination_namespace,
-            'k8s.cluster.name': df.cluster_name,
-            'px.cluster.id': df.cluster_id,
-            'instrumentation.provider': df.pixie,
-          },
-          data=[
+            # Export client span format for the client side of the request
             px.otel.trace.Span(
               name=df.query,
               start_time=df.start_time,
               end_time=df.time_,
               kind=px.otel.trace.SPAN_KIND_SERVER,
               attributes={
+                'service.instance.id': df.source_pod,
+                'k8s.namespace.name': df.source_namespace,
+                'mysql.service.name': df.destination_service,
+                'mysql.pod.name': df.destination_pod,
+                'mysql.namespace.name': df.destination_namespace,
+                'k8s.cluster.name': df.cluster_name,
+                'px.cluster.id': df.cluster_id,
+                'instrumentation.provider': df.pixie,
                 'mysql.req_cmd': df.req_cmd,
                 'mysql.req_body': df.req_body,
                 'mysql.req_bytes': df.req_bytes,
@@ -616,6 +589,23 @@ presetScripts:
                 'mysql.resp_latency': df.latency,
                 'mysql.resp_status': df.resp_status,
                 'mysql.resp_body': df.resp_body,
+                'db.system': df.db_system,
+              },
+            ),
+            # Export server span format for the server (MySQL) side of the request
+            px.otel.trace.Span(
+              name=df.query,
+              start_time=df.start_time,
+              end_time=df.time_,
+              kind=px.otel.trace.SPAN_KIND_CLIENT,
+              attributes={
+                'k8s.container.name': df.source_container,
+                'service.instance.id': df.source_pod,
+                'k8s.pod.name': df.source_pod,
+                'k8s.namespace.name': df.source_namespace,
+                'px.cluster.id': df.cluster_id,
+                'k8s.cluster.name': df.cluster_name,
+                'instrumentation.provider': df.pixie,
                 'db.system': df.db_system,
               },
             ),
@@ -1146,8 +1136,8 @@ presetScripts:
 
       # Convert latency from ns units to ms units.
       # Kafka/NATS/AMQP measure latency differently than the rest of the Pixie protocols.
-      df.start_time = time_
-      df.end_time = time_ + latency
+      df.start_time = df.time_
+      df.end_time = df.time_ + df.latency
       df.latency = df.latency / (1000.0 * 1000.0)
 
       # Get throughput by adding size of message_sets. Note that this is the total size of the


### PR DESCRIPTION
We had a few errors that showed up when the New Relic integration pulls these scripts.
The plugin disallows multiple `px.export` calls and we had made a minor mistake when changing another script.