### PR TITLE
Update DNS export scripts to use dns_rcode_name UDF.

### DIFF
--- a/plugins/new-relic/retention.yaml
+++ b/plugins/new-relic/retention.yaml
@@ -475,7 +475,7 @@ presetScripts:
       def add_source_dest_columns(df):
           df.pod = df.ctx['pod']
           df.namespace = df.ctx['namespace']
-          df.container = df.ctx['container'] 
+          df.container = df.ctx['container']
 
           # If remote_addr is a pod, get its name. If not, use IP address.
           df.ra_pod = px.pod_id_to_pod_name(px.ip_to_pod_id(df.remote_addr))
@@ -1273,30 +1273,6 @@ presetScripts:
       #px:set max_output_rows_per_table=10000
       import px
 
-      def dns_rcode_name(df, input_col_name, output_col_name):
-          df[output_col_name] = 'UNKNOWN'
-          df[output_col_name] = px.select(df[input_col_name]==0, 'NOERROR', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==1, 'FORMERR', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==2, 'SERVFAIL', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==3, 'NXDOMAIN', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==4, 'NOTIMP', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==5, 'REFUSED', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==6, 'YXDOMAIN', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==7, 'YXRRSET', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==8, 'NXRRSET', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==9, 'NOTAUTH', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==10, 'NOTZONE', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==11, 'DSOTYPENI', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==16, 'BADVERS', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==17, 'BADKEY', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==18, 'BADTIME', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==19, 'BADMODE', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==20, 'BADNAME', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==21, 'BADALG', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==22, 'BADTRUNC', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==23, 'BADCOOKIE', df[output_col_name])
-          return df
-
       df = px.DataFrame('dns_events', start_time=px.plugin.start_time, end_time=px.plugin.end_time)
       df = df[df.trace_role == 1]
       df = df.drop(['trace_role'])
@@ -1312,7 +1288,7 @@ presetScripts:
       df.queries = px.pluck(df.req_body, 'queries')
       df.answers = px.pluck(df.resp_body, 'answers')
       df.rcode = px.pluck_int64(df.resp_header, 'rcode')
-      df = dns_rcode_name(df, 'rcode', 'rcode_name')
+      df.rcode_name = px.dns_rcode_name(df.rcode)
       df.resolved = px.contains(df.answers, 'name')
       df.query = px.replace('.*"name":"(.*?)".*', df.queries, '\\1')
       df.query_type = px.replace('.*"type":"(.*?)".*', df.queries, '\\1')
@@ -1401,30 +1377,6 @@ presetScripts:
       #px:set max_output_rows_per_table=500
       import px
 
-      def dns_rcode_name(df, input_col_name, output_col_name):
-          df[output_col_name] = 'UNKNOWN'
-          df[output_col_name] = px.select(df[input_col_name]==0, 'NOERROR', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==1, 'FORMERR', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==2, 'SERVFAIL', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==3, 'NXDOMAIN', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==4, 'NOTIMP', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==5, 'REFUSED', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==6, 'YXDOMAIN', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==7, 'YXRRSET', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==8, 'NXRRSET', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==9, 'NOTAUTH', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==10, 'NOTZONE', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==11, 'DSOTYPENI', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==16, 'BADVERS', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==17, 'BADKEY', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==18, 'BADTIME', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==19, 'BADMODE', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==20, 'BADNAME', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==21, 'BADALG', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==22, 'BADTRUNC', df[output_col_name])
-          df[output_col_name] = px.select(df[input_col_name]==23, 'BADCOOKIE', df[output_col_name])
-          return df
-
       df = px.DataFrame('dns_events', start_time=px.plugin.start_time, end_time=px.plugin.end_time)
       df = df[df.trace_role == 1]
       df = df.drop(['trace_role'])
@@ -1442,7 +1394,7 @@ presetScripts:
       df.queries = px.pluck(df.req_body, 'queries')
       df.answers = px.pluck(df.resp_body, 'answers')
       df.rcode = px.pluck_int64(df.resp_header, 'rcode')
-      df = dns_rcode_name(df, 'rcode', 'rcode_name')
+      df.rcode_name = px.dns_rcode_name(df.rcode)
       df.resolved = px.contains(df.answers, 'name')
 
       df.query = px.replace('.*"name":"(.*?)".*', df.queries, '\\1')


### PR DESCRIPTION
The [dns_rcode_name()](https://docs.px.dev/reference/pxl/udf/dns_rcode_name/) UDF was added in vizier release 0.12.8 ([commit](https://github.com/pixie-io/pixie/commit/46c9d471a9ecea11e33e768c8ec2f6810dd43dbf)). 