### PR TITLE
Add req/resp headers to New Relic's HTTP Spans

### DIFF
--- a/plugins/new-relic/plugin.yaml
+++ b/plugins/new-relic/plugin.yaml
@@ -3,8 +3,8 @@ id: "new-relic"
 logo: >
   <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M17.7865 8.30799V15.692L11.3928 19.3848V24L21.7857 18.0004V5.99963L17.7865 8.30799Z" fill="#00AC69"/><path d="M11.3929 4.61672L17.7866 8.30798L21.7858 5.99962L11.3929 0L1 5.99962L4.99774 8.30798L11.3929 4.61672Z" fill="#1CE783"/><path d="M7.39517 14.3091V21.6932L11.3929 24V12.0008L1 5.99963V10.6164L7.39517 14.3091Z" fill="white"/></svg>
 description: "The official New Relic plugin for Pixie. This plugin will help export your Pixie data to New Relic. Check out the tutorial: https://docs.pixielabs.ai/tutorials/integrations/nr-retention"
-version: "1.4.7"
-updated: "2023-01-18"
+version: "1.4.8"
+updated: "2023-02-14"
 keywords:
   - newrelic
   - NR1

--- a/plugins/new-relic/retention.yaml
+++ b/plugins/new-relic/retention.yaml
@@ -198,6 +198,8 @@ presetScripts:
                 'http.host': df.host,
                 'http.status_code': df.resp_status,
                 'http.user_agent': df.user_agent,
+                'http.req_headers': df.req_headers,
+                'http.resp_headers': df.resp_headers,
               },
             ),
           ],


### PR DESCRIPTION
This information is usually included in a span, so this PR adds it to the HTTP spans that are sent in the New Relic plugin.